### PR TITLE
syntax fixes

### DIFF
--- a/src/mpm.odd
+++ b/src/mpm.odd
@@ -16,12 +16,8 @@
                 <tei:edition n="2.0.0"/>
             </tei:editionStmt>
             
-            <tei:revisionDesc>
-                <tei:change status="1.0.0" who="Benjamin Wolff Bohl">Initial schema definition.</tei:change>
-                <tei:change status="2.0.0" who="Axel Berndt">Reboot of the schema definition after some conceptual revisions and in compliance with the <tei:ref target="https://github.com/cemfi/meico">MPM API implementation</tei:ref>.</tei:change>
-            </tei:revisionDesc>
-            
             <tei:publicationStmt>
+                <tei:publisher>Axel Berndt</tei:publisher>
                 <tei:availability>
                     <tei:licence target="http://creativecommons.org/licenses/by-sa/4.0/">
                         Distributed under Creative Commons Attribution-ShareAlike 4.0 License
@@ -41,7 +37,17 @@
                     <tei:p>In the MPM format definition we make use of the TEI ODD format that is published under CC-BY-3.0 and BSD-2.0. MPM material can be licensed differently depending on the use you intend to make of it. Hence it is made available under both the CC BY-SA and BSD-2 licences. The CC BY-SA licence is generally appropriate for usages which treat MPM content as data or documentation. The BSD-2 licence is generally appropriate for usage of MPM content in a software environment. For further information or clarification, please contact the <tei:ref target="mailto:axel.berndt@th-owl.de">Axel Berndt</tei:ref>.</tei:p>
                 </tei:availability>
             </tei:publicationStmt>
+            
+            <tei:sourceDesc>
+                <tei:p>born digital</tei:p>
+            </tei:sourceDesc>
+            
         </tei:fileDesc>
+        
+        <tei:revisionDesc>
+            <tei:change status="1.0.0" who="Benjamin Wolff Bohl">Initial schema definition.</tei:change>
+            <tei:change status="2.0.0" who="Axel Berndt">Reboot of the schema definition after some conceptual revisions and in compliance with the <tei:ref target="https://github.com/cemfi/meico">MPM API implementation</tei:ref>.</tei:change>
+        </tei:revisionDesc>
     </tei:teiHeader>
     
     <tei:text>
@@ -52,75 +58,77 @@
         </tei:body>
         
         <tei:back>
-            <tei:schemaSpec ident="mpm" start="mpm" prefix="mpm." ns="http://www.cemfi.de/mpm/ns/1.0" docLang="en" defaultExceptions="http://www.tei-c.org/ns/1.0 teix:egXML http://www.cemfi.de/mpm/ns/1.0">
-                
-                <!-- the modules -->
-                <xinclude:include href="specs/mpm.core.xml"/>
-                <xinclude:include href="specs/mpm.resources.xml"/>
-                <xinclude:include href="specs/mpm.midi.xml"/>
-                
-                <!-- the attribute classes -->
-                <xinclude:include href="specs/att.reference.resource.xml"/>
-                <xinclude:include href="specs/att.id.xml"/>
-                <xinclude:include href="specs/att.name.xml"/>
-                <xinclude:include href="specs/att.number.xml"/>
-                <xinclude:include href="specs/att.pulsesPerQuarter.xml"/>
-
-                <!-- the model classes -->
-                <xinclude:include href="specs/model.performanceLike.xml"/>
-                <xinclude:include href="specs/model.globalLike.xml"/>
-                <xinclude:include href="specs/model.partLike.xml"/>
-                
-                <!-- the elements -->
-                <xinclude:include href="specs/mpm.xml"/>
-                <xinclude:include href="specs/relatedResources.xml"/>
-                <xinclude:include href="specs/resource.xml"/>
-                <xinclude:include href="specs/performance.xml"/>
-                <xinclude:include href="specs/global.xml"/>
-                <xinclude:include href="specs/part.xml"/>
-                <xinclude:include href="specs/header.xml"/>
-                <xinclude:include href="specs/dated.xml"/>
-
-                
-                
-                
-                
-                
-                
-                
-                
-                <tei:classSpec ident="model.mapLike" type="model" module="mpm.core" mode="add">
-                    <tei:gloss>MPM core module</tei:gloss>
-                    <tei:desc>All elements, attributes, macros, classes, and models of the MPM format are part of this module.</tei:desc>
-                </tei:classSpec>
-                
-                <tei:elementSpec ident="dynamicsMap" module="mpm.core" mode="add" ns="http://www.cemfi.de/mpm/ns/1.0">
-                    <tei:classes>
-                        <tei:memberOf key="model.mapLike"/>
-                    </tei:classes>
-                    <tei:content>
-                        <tei:alternate minOccurs="0" maxOccurs="unbounded">
-                            <tei:elementRef key="dynamics" minOccurs="0"/>
-                            <tei:elementRef key="style" minOccurs="0"/>
-                        </tei:alternate>
-                    </tei:content>
-                    <!-- dokuzeugs -->
-                </tei:elementSpec>
-                
-                <tei:classSpec ident="att.startStyle" type="atts" module="mpm.core" mode="add">
-                    <tei:attList>
-                        <tei:attDef ident="startStyle" usage="req">
-                            <tei:gloss>MPM core module</tei:gloss>
-                            <tei:desc>All elements, attributes, macros, classes, and models of the MPM format are part of this module.</tei:desc>
-                            <tei:datatype>
-                                <tei:dataRef name="teidata.text"/>  <!-- teidata.text für mehrere Worte, .word für ein Wort, .count für nichtnegative Integers, double, int -->
-                            </tei:datatype>
-                        </tei:attDef>
-                    </tei:attList>
-                </tei:classSpec>
-
-                <!-- ... -->
-            </tei:schemaSpec>
+            <tei:div>
+                <tei:schemaSpec ident="mpm" start="mpm" prefix="mpm." ns="http://www.cemfi.de/mpm/ns/1.0" docLang="en" defaultExceptions="http://www.tei-c.org/ns/1.0 teix:egXML http://www.cemfi.de/mpm/ns/1.0">
+                    
+                    <!-- the modules -->
+                    <xinclude:include href="specs/mpm.core.xml"/>
+                    <xinclude:include href="specs/mpm.resources.xml"/>
+                    <xinclude:include href="specs/mpm.midi.xml"/>
+                    
+                    <!-- the attribute classes -->
+                    <xinclude:include href="specs/att.reference.resource.xml"/>
+                    <xinclude:include href="specs/att.id.xml"/>
+                    <xinclude:include href="specs/att.name.xml"/>
+                    <xinclude:include href="specs/att.number.xml"/>
+                    <xinclude:include href="specs/att.pulsesPerQuarter.xml"/>
+                    
+                    <!-- the model classes -->
+                    <xinclude:include href="specs/model.performanceLike.xml"/>
+                    <xinclude:include href="specs/model.globalLike.xml"/>
+                    <xinclude:include href="specs/model.partLike.xml"/>
+                    
+                    <!-- the elements -->
+                    <xinclude:include href="specs/mpm.xml"/>
+                    <xinclude:include href="specs/relatedResources.xml"/>
+                    <xinclude:include href="specs/resource.xml"/>
+                    <xinclude:include href="specs/performance.xml"/>
+                    <xinclude:include href="specs/global.xml"/>
+                    <xinclude:include href="specs/part.xml"/>
+                    <xinclude:include href="specs/header.xml"/>
+                    <xinclude:include href="specs/dated.xml"/>
+                    
+                    
+                    
+                    
+                    
+                    
+                    
+                    
+                    
+                    <tei:classSpec ident="model.mapLike" type="model" module="mpm.core" mode="add">
+                        <tei:gloss>MPM core module</tei:gloss>
+                        <tei:desc>All elements, attributes, macros, classes, and models of the MPM format are part of this module.</tei:desc>
+                    </tei:classSpec>
+                    
+                    <tei:elementSpec ident="dynamicsMap" module="mpm.core" mode="add" ns="http://www.cemfi.de/mpm/ns/1.0">
+                        <tei:classes>
+                            <tei:memberOf key="model.mapLike"/>
+                        </tei:classes>
+                        <tei:content>
+                            <tei:alternate minOccurs="0" maxOccurs="unbounded">
+                                <tei:elementRef key="dynamics" minOccurs="0"/>
+                                <tei:elementRef key="style" minOccurs="0"/>
+                            </tei:alternate>
+                        </tei:content>
+                        <!-- dokuzeugs -->
+                    </tei:elementSpec>
+                    
+                    <tei:classSpec ident="att.startStyle" type="atts" module="mpm.core" mode="add">
+                        <tei:attList>
+                            <tei:attDef ident="startStyle" usage="req">
+                                <tei:gloss>MPM core module</tei:gloss>
+                                <tei:desc>All elements, attributes, macros, classes, and models of the MPM format are part of this module.</tei:desc>
+                                <tei:datatype>
+                                    <tei:dataRef name="teidata.text"/>  <!-- teidata.text für mehrere Worte, .word für ein Wort, .count für nichtnegative Integers, double, int -->
+                                </tei:datatype>
+                            </tei:attDef>
+                        </tei:attList>
+                    </tei:classSpec>
+                    
+                    <!-- ... -->
+                </tei:schemaSpec>
+            </tei:div>
         </tei:back>
     </tei:text>
 </tei:TEI>

--- a/src/specs/att.id.xml
+++ b/src/specs/att.id.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<tei:classSpec ident="att.att.id" type="atts" module="mpm.core" mode="add" ns="http://www.cemfi.de/mpm/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0">
+<tei:classSpec ident="att.att.id" type="atts" module="mpm.core" mode="add" xmlns:tei="http://www.tei-c.org/ns/1.0">
     <tei:gloss>xml:id attribute class</tei:gloss>
     
     <tei:desc>This attribute class supplies the <tei:att>xml:id</tei:att> attribute.</tei:desc>

--- a/src/specs/att.midiRouting.xml
+++ b/src/specs/att.midiRouting.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<tei:classSpec ident="att.midiRouting" type="atts" module="mpm.midi" mode="add" ns="http://www.cemfi.de/mpm/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0">
+<tei:classSpec ident="att.midiRouting" type="atts" module="mpm.midi" mode="add" xmlns:tei="http://www.tei-c.org/ns/1.0">
     <tei:gloss>MIDI routing attributes class</tei:gloss>
     
     <tei:desc>This attribute class provides attributes <tei:att>midi.channel</tei:att> and <tei:att>midi.port</tei:att>.</tei:desc>

--- a/src/specs/att.name.xml
+++ b/src/specs/att.name.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<tei:classSpec ident="att.name" type="atts" module="mpm.core" mode="add" ns="http://www.cemfi.de/mpm/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0">
+<tei:classSpec ident="att.name" type="atts" module="mpm.core" mode="add" xmlns:tei="http://www.tei-c.org/ns/1.0">
     <tei:gloss>name attribute class</tei:gloss>
     
     <tei:desc>This attribute class provides attribute <tei:att>name</tei:att>.</tei:desc>

--- a/src/specs/att.number.xml
+++ b/src/specs/att.number.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<tei:classSpec ident="att.number" type="atts" module="mpm.core" mode="add" ns="http://www.cemfi.de/mpm/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0">
+<tei:classSpec ident="att.number" type="atts" module="mpm.core" mode="add" xmlns:tei="http://www.tei-c.org/ns/1.0">
     <tei:gloss>number attribute class</tei:gloss>
     
     <tei:desc>This attribute class provides attribute <tei:att>number</tei:att>.</tei:desc>

--- a/src/specs/att.pulsesPerQuarter.xml
+++ b/src/specs/att.pulsesPerQuarter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<tei:classSpec ident="att.pulsesPerQuarter" type="atts" module="mpm.midi" mode="add" ns="http://www.cemfi.de/mpm/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0">
+<tei:classSpec ident="att.pulsesPerQuarter" type="atts" module="mpm.midi" mode="add" xmlns:tei="http://www.tei-c.org/ns/1.0">
     <tei:gloss>pulsesPerQuarter attribute class</tei:gloss>
     
     <tei:desc>This attribute class provides attribute <tei:att>pulsesPerQuarter</tei:att>.</tei:desc>

--- a/src/specs/att.reference.resource.xml
+++ b/src/specs/att.reference.resource.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<tei:classSpec ident="att.reference.resource" type="atts" module="mpm.resources" mode="add" ns="http://www.cemfi.de/mpm/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0">
+<tei:classSpec ident="att.reference.resource" type="atts" module="mpm.resources" mode="add" xmlns:tei="http://www.tei-c.org/ns/1.0">
     <tei:gloss>resource reference attributes</tei:gloss>
     
     <tei:desc>This attribute class provides attributes for referencing an external resource.</tei:desc>

--- a/src/specs/model.globalLike.xml
+++ b/src/specs/model.globalLike.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<tei:classSpec ident="model.globalLike" type="model" module="mpm.core" mode="add" ns="http://www.cemfi.de/mpm/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0">
+<tei:classSpec ident="model.globalLike" type="model" module="mpm.core" mode="add" xmlns:tei="http://www.tei-c.org/ns/1.0">
     <tei:gloss>globalLike model class</tei:gloss>
     
     <tei:desc>This model class defines the basic structure of MPM <tei:gi>global</tei:gi> elements.</tei:desc>

--- a/src/specs/model.globalLike.xml
+++ b/src/specs/model.globalLike.xml
@@ -4,12 +4,4 @@
     
     <tei:desc>This model class defines the basic structure of MPM <tei:gi>global</tei:gi> elements.</tei:desc>
     
-    <tei:listRef>
-        <tei:content>
-            <tei:sequence preserveOrder="false">
-                <tei:elementRef key="header" minOccurs="1" maxOccurs="1"/>
-                <tei:elementRef key="dated" minOccurs="1" maxOccurs="1"/>
-            </tei:sequence>
-        </tei:content>
-    </tei:listRef>
 </tei:classSpec>

--- a/src/specs/model.partLike.xml
+++ b/src/specs/model.partLike.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<tei:classSpec ident="model.partLike" type="model" module="mpm.core" mode="add" ns="http://www.cemfi.de/mpm/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0">
+<tei:classSpec ident="model.partLike" type="model" module="mpm.core" mode="add" xmlns:tei="http://www.tei-c.org/ns/1.0">
     <tei:gloss>partLike model class</tei:gloss>
     
     <tei:desc>This model class defines the basic structure of MPM <tei:gi>part</tei:gi> elements.</tei:desc>

--- a/src/specs/model.performanceLike.xml
+++ b/src/specs/model.performanceLike.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<tei:classSpec ident="model.performanceLike" type="model" module="mpm.core" mode="add" ns="http://www.cemfi.de/mpm/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0">
+<tei:classSpec ident="model.performanceLike" type="model" module="mpm.core" mode="add" xmlns:tei="http://www.tei-c.org/ns/1.0">
     <tei:gloss>performanceLike model class</tei:gloss>
     
     <tei:desc>This model class defines the basic structure of MPM <tei:gi>performance</tei:gi> elements.</tei:desc>

--- a/src/specs/model.performanceLike.xml
+++ b/src/specs/model.performanceLike.xml
@@ -10,10 +10,4 @@
         <tei:memberOf key="att.pulsesPerQuarter"/>
     </tei:classes>
 
-    <tei:listRef>
-        <tei:content>
-            <tei:elementRef key="global" minOccurs="1" maxOccurs="1"/>
-            <tei:elementRef key="part" minOccurs="0" maxOccurs="unbounded"/>
-        </tei:content>
-    </tei:listRef>
 </tei:classSpec>

--- a/src/specs/mpm.core.xml
+++ b/src/specs/mpm.core.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<tei:moduleSpec ident="mpm.core" mode="add" ns="http://www.cemfi.de/mpm/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0">
+<tei:moduleSpec ident="mpm.core" mode="add" xmlns:tei="http://www.tei-c.org/ns/1.0">
     <tei:gloss>MPM core module</tei:gloss>
     <tei:desc>All of MPM's core elements, attributes, macros, and classes are part of this module.</tei:desc>
 </tei:moduleSpec>

--- a/src/specs/mpm.midi.xml
+++ b/src/specs/mpm.midi.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<tei:moduleSpec ident="mpm.midi" mode="add" ns="http://www.cemfi.de/mpm/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0">
+<tei:moduleSpec ident="mpm.midi" mode="add" xmlns:tei="http://www.tei-c.org/ns/1.0">
     <tei:gloss>MPM MIDI module</tei:gloss>
     <tei:desc>This module groups parts of the schema that are derivatives or related to the MIDI standard (Musical Instrument Digital Interface).</tei:desc>
 </tei:moduleSpec>

--- a/src/specs/mpm.resources.xml
+++ b/src/specs/mpm.resources.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<tei:moduleSpec ident="mpm.resources" mode="add" ns="http://www.cemfi.de/mpm/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0">
+<tei:moduleSpec ident="mpm.resources" mode="add" xmlns:tei="http://www.tei-c.org/ns/1.0">
     <tei:gloss>MPM resources module</tei:gloss>
     <tei:desc>All of MPM's resource-related elements, attributes, and classes are part of this module.</tei:desc>
 </tei:moduleSpec>

--- a/src/specs/relatedResources.xml
+++ b/src/specs/relatedResources.xml
@@ -9,7 +9,7 @@
     </tei:content>
     
     <tei:exemplum>
-        <tei:p>The element <gi>relatedResources</gi> holds one or more references to other resources, e.g. the MEI file from which it was derived or an MSM file which it is intended to be applied to.</tei:p>
+        <tei:p>The element <tei:gi>relatedResources</tei:gi> holds one or more references to other resources, e.g. the MEI file from which it was derived or an MSM file which it is intended to be applied to.</tei:p>
         <egXML xmlns="http://www.tei-c.org/ns/Examples">
             <relatedResources>
                 <resource uri="pathTo/music.mei" type="mei"/>

--- a/src/specs/resource.xml
+++ b/src/specs/resource.xml
@@ -13,7 +13,7 @@
     </tei:content>
     
     <tei:exemplum>
-        <tei:p>The element <gi>relatedResources</gi> holds one or more references to other sources, e.g. the MEI file from which it was derived or an MSM file which it is intended to be applied to.</tei:p>
+        <tei:p>The element <tei:gi>relatedResources</tei:gi> holds one or more references to other sources, e.g. the MEI file from which it was derived or an MSM file which it is intended to be applied to.</tei:p>
         <egXML xmlns="http://www.tei-c.org/ns/Examples">
             <relatedResources>
                 <resource uri="pathTo/music.mei" type="mei"/>


### PR DESCRIPTION
these changes will turn the current structure into a valid TEI ODD document. Most changes are non-disruptive, yet the idea of having (default) tei:content in a classSpec won't work and needs to be replaced.