### PR TITLE
v2.1.0

### DIFF
--- a/sample encodings/Georg P. Telemann - Grave - TWV 51-D7/Telemann - Grave.mpm
+++ b/sample encodings/Georg P. Telemann - Grave - TWV 51-D7/Telemann - Grave.mpm
@@ -13,15 +13,14 @@
             
             3. Romantic: This performance features distinct macro dynamics and timing. Quite prominent is also the swing-like micro timing (rubato), more pronounced in the violins, less in the bass. It is based on a performance by Ludwig Güttler and the "Neues Bachisches Collegium Musicum".
         </comment>
+        <relatedResources>
+            <resource uri="Telemann - Grave.mid" type="midi"/>
+            <resource uri="Telemann - Grave.msm" type="msm"/>
+            <resource uri="Telemann - Grave_Baroque.pdf" type="pdf"/>
+            <resource uri="Telemann - Grave_Romantic.pdf" type="pdf"/>
+            <resource uri="Telemann - Grave_Fast.pdf" type="pdf"/>
+        </relatedResources>
     </metadata>
-
-    <relatedResources>
-        <resource uri="Telemann - Grave.mid" type="midi"/>
-        <resource uri="Telemann - Grave.msm" type="msm"/>
-        <resource uri="Telemann - Grave_Baroque.pdf" type="pdf"/>
-        <resource uri="Telemann - Grave_Romantic.pdf" type="pdf"/>
-        <resource uri="Telemann - Grave_Fast.pdf" type="pdf"/>
-    </relatedResources>
 
     <performance name="Baroque" pulsesPerQuarter="720">
         <global>

--- a/sample encodings/Johann S. Bach - Minuet No 2 - BWV 1007/BWV 1007 Minuet No 2.mpm
+++ b/sample encodings/Johann S. Bach - Minuet No 2 - BWV 1007/BWV 1007 Minuet No 2.mpm
@@ -5,12 +5,13 @@
     <metadata>
         <author>Pablo Carra</author>
         <comment>This MPM describes a performance of the Minuet No 2 by Johann Sebastian Bach from the first Cello Suite (BWV 1007). Heinrich Schiff's performance was used as inspiration, but this is in no way an attempt at reconstruction.</comment>
+        <relatedResources>
+            <resource uri="BWV 1007 Minuet No 2.mid" type="midi"/>
+            <resource uri="BWV 1007 Minuet No 2.msm" type="msm"/>
+            <resource uri="BWV 1007 Minuet No 2.pdf" type="pdf"/>
+        </relatedResources>
     </metadata>
-    <relatedResources>
-        <resource uri="BWV 1007 Minuet No 2.mid" type="midi"/>
-        <resource uri="BWV 1007 Minuet No 2.msm" type="msm"/>
-        <resource uri="BWV 1007 Minuet No 2.pdf" type="pdf"/>
-    </relatedResources>
+
     <performance name="like Heinrich Schiff" pulsesPerQuarter="480">
         <global>
             <header>

--- a/sample encodings/Melchior Vulpius - Die helle Sonn/Die helle Sonn.mpm
+++ b/sample encodings/Melchior Vulpius - Die helle Sonn/Die helle Sonn.mpm
@@ -13,14 +13,13 @@
             
             All performances were coneived by author 1 Pablo Carra. Author 2 Axel Berndt has added minor editings, mostly code polishing. 
         </comment>
+        <relatedResources>
+            <resource uri="Die helle Sonn.mid" type="midi"/>
+            <resource uri="Die helle Sonn.msm" type="msm"/>
+            <resource uri="Die helle Sonn_Baroque.pdf" type="pdf"/>
+            <resource uri="Die helle Sonn_Romantic.pdf" type="pdf"/>
+        </relatedResources>
     </metadata>
-
-    <relatedResources>
-        <resource uri="Die helle Sonn.mid" type="midi"/>
-        <resource uri="Die helle Sonn.msm" type="msm"/>
-        <resource uri="Die helle Sonn_Baroque.pdf" type="pdf"/>
-        <resource uri="Die helle Sonn_Romantic.pdf" type="pdf"/>
-    </relatedResources>
 
     <performance name="Baroque" pulsesPerQuarter="480">
         <global>

--- a/src/mpm.odd
+++ b/src/mpm.odd
@@ -14,7 +14,7 @@
             </tei:titleStmt>
             
             <tei:editionStmt>
-                <tei:edition n="2.0.3"/>
+                <tei:edition n="2.1.0"/>
             </tei:editionStmt>
             
             <tei:publicationStmt>
@@ -51,6 +51,7 @@
             <tei:change status="2.0.1" who="Axel Berndt">The order of child elements of <tei:gi>mpm</tei:gi> has been removed.</tei:change>
             <tei:change status="2.0.2" who="Axel Berndt">Fix in <tei:gi>accentuationPattern</tei:gi>, removed memberOf with non-existing class att.accentuationPatternDef.</tei:change>
             <tei:change status="2.0.3" who="Axel Berndt">Added package mpm.metadata with elements <tei:gi>metadata</tei:gi>, <tei:gi>author</tei:gi> and <tei:gi>comment</tei:gi>.</tei:change>
+            <tei:change status="2.1.0" who="Axel Berndt">Moved element <tei:gi>relatedResources</tei:gi> to element <tei:gi>metadata</tei:gi>.</tei:change>
         </tei:revisionDesc>
     </tei:teiHeader>
     
@@ -105,16 +106,13 @@
                 <tei:div type="chapter">
                     <tei:head>The Basic Structure</tei:head>
                     
-                    <tei:p>The following code example shows the topmost structure of MPM documents. The root node <tei:gi>mpm</tei:gi> has three kinds of children, one element <tei:gi>metadata</tei:gi> (optional), one element <tei:gi>relatedResources</tei:gi> (optional) and one or more elements <tei:gi>performance</tei:gi>, each with a unique <tei:att>name</tei:att>.</tei:p>
+                    <tei:p>The following code example shows the topmost structure of MPM documents. The root node <tei:gi>mpm</tei:gi> has three kinds of children, one element <tei:gi>metadata</tei:gi> (optional) and one or more elements <tei:gi>performance</tei:gi>, each with a unique <tei:att>name</tei:att>.</tei:p>
                     
                     <egXML xmlns="http://www.tei-c.org/ns/Examples">
                         <mpm>
                             <metadata>
                                 ...
                             </metadata>
-                            <relatedResources> 
-                                ... 
-                            </relatedResources>
                             <performance name="a performance" pulsesPerQuarter="720">
                                 ...
                             </performance>
@@ -129,7 +127,7 @@
                 <tei:div type="chapter">
                     <tei:head>Metadata</tei:head>
                     
-                    <tei:p>Element <tei:gi>metadata</tei:gi> is optional. Here authorship can be stated and/or textual comments made.</tei:p>
+                    <tei:p>Element <tei:gi>metadata</tei:gi> is optional. Here authorship can be stated, textual comments made and related resources referred.</tei:p>
                     
                     <egXML xmlns="http://www.tei-c.org/ns/Examples">
                         <metadata>
@@ -137,6 +135,9 @@
                             <comment>The first performance, authored by author no. 1, is based on a violin treatise from 1678.</comment>
                             <author number="2">John Smith</author>
                             <comment>Author no. 2 made the second performance on the basis of a tape recording by famous pianist Clare Clear.</comment>
+                            <relatedResources>
+                                ...
+                            </relatedResources>
                         </metadata>
                     </egXML>
                 </tei:div>

--- a/src/specs/metadata.xml
+++ b/src/specs/metadata.xml
@@ -1,17 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://tei-c.org/release/xml/tei/custom/schema/relaxng/tei_odds.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://tei-c.org/release/xml/tei/custom/schema/relaxng/tei_odds.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<tei:elementSpec ident="metadata" module="mpm.metadata" mode="add" ns="http://www.cemfi.de/mpm/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0">
+<tei:elementSpec ident="metadata" module="mpm.metadata" mode="add" ns="http://www.cemfi.de/mpm/ns/1.0" 
+    xmlns:tei="http://www.tei-c.org/ns/1.0" 
+    xmlns:relaxng="http://relaxng.org/ns/structure/1.0" 
+    xmlns:schematron="http://purl.oclc.org/dsdl/schematron">
     <tei:gloss>metadata</tei:gloss>
     
     <tei:desc>This element can be used to provide contextual information about the encoding in this MPM file.</tei:desc>
     
     <tei:content>
-        <tei:alternate minOccurs="1" maxOccurs="unbounded">
-            <tei:elementRef key="author"/>
-            <tei:elementRef key="comment"/>
-        </tei:alternate>
+        <relaxng:interleave>
+            <tei:elementRef key="author" minOccurs="0" maxOccurs="unbounded"/>
+            <tei:elementRef key="comment" minOccurs="0" maxOccurs="unbounded"/>
+            <tei:elementRef key="relatedResources" minOccurs="0" maxOccurs="1"/>
+        </relaxng:interleave>
     </tei:content>
+    
+    <tei:constraintSpec ident="metadata_nonempty_constraint" scheme="schematron">
+        <tei:desc>Element <tei:gi>metadata</tei:gi> is not allowed to be empty</tei:desc>
+        <tei:constraint>
+            <schematron:assert test="count(child::*) > 0">
+                Element metadata is not allowed to be empty.
+            </schematron:assert>
+        </tei:constraint>
+    </tei:constraintSpec>
     
     <tei:exemplum>
         <egXML xmlns="http://www.tei-c.org/ns/Examples">
@@ -20,6 +33,11 @@
                 <comment>The first performance, authored by author no. 1, is based on a violin treatise from 1678.</comment>
                 <author number="2">John Smith</author>
                 <comment>Author no. 2 made the second performance on the basis of a tape recording by famous pianist Clare Clear.</comment>
+                <relatedResources>
+                    <resource uri="pathTo/music.mei" type="mei"/>
+                    <resource uri="pathTo/music.msm" type="msm"/>
+                    <!-- further resource references -->
+                </relatedResources>
             </metadata>
         </egXML>
     </tei:exemplum>

--- a/src/specs/mpm.resources.xml
+++ b/src/specs/mpm.resources.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://tei-c.org/release/xml/tei/custom/schema/relaxng/tei_odds.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://tei-c.org/release/xml/tei/custom/schema/relaxng/tei_odds.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<tei:moduleSpec ident="mpm.resources" mode="add" xmlns:tei="http://www.tei-c.org/ns/1.0">
+<tei:moduleSpec ident="mpm.resources" module="mpm.metadata" mode="add" xmlns:tei="http://www.tei-c.org/ns/1.0">
     <tei:gloss>MPM resources module</tei:gloss>
     <tei:desc>All of MPM's resource-related elements, attributes, and classes are part of this module.</tei:desc>
 </tei:moduleSpec>

--- a/src/specs/mpm.xml
+++ b/src/specs/mpm.xml
@@ -2,29 +2,29 @@
 <?xml-model href="https://tei-c.org/release/xml/tei/custom/schema/relaxng/tei_odds.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://tei-c.org/release/xml/tei/custom/schema/relaxng/tei_odds.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <tei:elementSpec ident="mpm" module="mpm.core" mode="add" ns="http://www.cemfi.de/mpm/ns/1.0" 
-    xmlns:tei="http://www.tei-c.org/ns/1.0"
-    xmlns:relaxng="http://relaxng.org/ns/structure/1.0">
+    xmlns:tei="http://www.tei-c.org/ns/1.0">
     <tei:gloss>MPM document</tei:gloss>
     
     <tei:desc>The root element of an MPM-conformant document.</tei:desc>
     
     <tei:content>
-        <relaxng:interleave>
-            <tei:elementRef key="metadata" minOccurs="0" maxOccurs="1"/>
-            <tei:elementRef key="relatedResources" minOccurs="0" maxOccurs="1"/>
-            <tei:elementRef key="performance" minOccurs="1" maxOccurs="unbounded"/>
-        </relaxng:interleave>
+        <tei:elementRef key="metadata" minOccurs="0" maxOccurs="1"/>
+        <tei:elementRef key="performance" minOccurs="1" maxOccurs="unbounded"/>
     </tei:content>
     
     <tei:exemplum>
         <tei:p>The basic structure of an MPM document looks like this.</tei:p>
         <egXML xmlns="http://www.tei-c.org/ns/Examples">
             <mpm>
-                <relatedResources>
-                    <resource uri="pathTo/music.mei" type="mei"/>
-                    <resource uri="pathTo/music.msm" type="msm"/>
-                    <!-- further resource references -->
-                </relatedResources>
+                <metadata>
+                    <author>Some One</author>
+                    <comment>comment</comment>
+                    <relatedResources>
+                        <resource uri="pathTo/music.mei" type="mei"/>
+                        <resource uri="pathTo/music.msm" type="msm"/>
+                        <!-- further resource references -->
+                    </relatedResources>
+                </metadata>
                 <performance name="a performance" pulsesPerQuarter="720">
                     <global>
                         <header>


### PR DESCRIPTION
v2.1.0
- Moved element `relatedResources` to element `metadata`.
- Updated example code and sample encodings accordingly.