### PR TITLE
v2.1.5

### DIFF
--- a/src/mpm.odd
+++ b/src/mpm.odd
@@ -14,7 +14,7 @@
             </tei:titleStmt>
             
             <tei:editionStmt>
-                <tei:edition n="2.1.4"/>
+                <tei:edition n="2.1.5"/>
             </tei:editionStmt>
             
             <tei:publicationStmt>
@@ -69,6 +69,7 @@
                 </tei:list>
             </tei:change>
             <tei:change status="2.1.4" who="Axel Berndt">Value range of attribute <tei:att>frameLength</tei:att> of element <tei:gi>temporalSpread</tei:gi> must be greater or equal to 0.0. Negative values are not allowed, at least in this context.</tei:change>
+            <tei:change status="2.1.5" who="Axel Berndt">Value range of attribute <tei:att>frameLength</tei:att> of element <tei:gi>temporalSpread</tei:gi> was defined with maxInclusive 0.0. This is fixed to minInclusive 0.0.</tei:change>
         </tei:revisionDesc>
     </tei:teiHeader>
     

--- a/src/specs/temporalSpread.xml
+++ b/src/specs/temporalSpread.xml
@@ -24,7 +24,7 @@
         <tei:attDef ident="frameLength" usage="opt" mode="change">
             <tei:datatype>
                 <tei:dataRef name="double">
-                    <tei:dataFacet name="maxInclusive" value="0.0"/>
+                    <tei:dataFacet name="minInclusive" value="0.0"/>
                 </tei:dataRef>
             </tei:datatype>
             <tei:defaultVal>0.0</tei:defaultVal>


### PR DESCRIPTION
Value range of attribute ´frameLength´ of element ´temporalSpread´ was defined with ´maxInclusive 0.0´. This is fixed to ´minInclusive 0.0´.