### PR TITLE
Ready for DocsGeneration

### DIFF
--- a/src/mpm.odd
+++ b/src/mpm.odd
@@ -953,6 +953,7 @@
                         <xinclude:include href="specs/accentuationPattern.xml"/>
                     <xinclude:include href="specs/ornamentationMap.xml"/>
                         <xinclude:include href="specs/ornament.xml"/>
+                            <xinclude:include href="specs/note.xml"/>
                     <xinclude:include href="specs/tempoMap.xml"/>
                         <xinclude:include href="specs/tempo.xml"/>
                     <xinclude:include href="specs/rubatoMap.xml"/>

--- a/src/specs/note.xml
+++ b/src/specs/note.xml
@@ -46,16 +46,16 @@
 
     <tei:exemplum>
          <tei:p>
-            The first <tei:gi>ornament</tei:gi> applies two alterations (#n1, #n2) to the principal note (#princNote1) creating an upper turn.
-            The second <tei:gi>ornament</tei:gi> defines a half tone trill ornament, starting with the auxiliary note (#n3) and landing on the principal note (#princNote2), with no repetition as the <tei:att>repetitions</tei:att> attribute is not specified and <tei:val>0</tei:val> by default.
+            The first <tei:gi>ornament</tei:gi> applies two alterations (#n2, #n3) to the principal note (#princNote1) creating an upper turn.
+            The second <tei:gi>ornament</tei:gi> defines a half tone trill ornament, starting with the auxiliary note (#n4) and landing on the principal note (#princNote2), with no repetition as the <tei:att>repetitions</tei:att> attribute is not specified and <tei:val>0</tei:val> by default.
         </tei:p>
         <egXML xmlns="http://www.tei-c.org/ns/Examples">
-            <ornament date="0.0" name.ref="upper turn" note.order="#n1 #princNote1 #n2 #princNote1">
-                <note xml:id="n1" interval.chromatic="1.0"/>
-                <note xml:id="n2" interval.chromatic="-1.0"/>
+            <ornament date="0.0" name.ref="upper turn" note.order="#n2 #princNote1 #n3 #princNote1">
+                <note xml:id="n2" interval.chromatic="1.0"/>
+                <note xml:id="n3" interval.chromatic="-1.0"/>
             </ornament>
-            <ornament date="720.0" name.ref="trill" note.order="|: #n3 #princNote2 :|">
-                <note xml:id="n3" interval.chromatic="1.0"/>
+            <ornament date="720.0" name.ref="trill" note.order="|: #n4 #princNote2 :|">
+                <note xml:id="n4" interval.chromatic="1.0"/>
             </ornament>
         </egXML>
     </tei:exemplum>

--- a/src/specs/temporalSpread.xml
+++ b/src/specs/temporalSpread.xml
@@ -2,7 +2,8 @@
 <?xml-model href="https://tei-c.org/release/xml/tei/custom/schema/relaxng/tei_odds.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://tei-c.org/release/xml/tei/custom/schema/relaxng/tei_odds.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <tei:elementSpec ident="temporalSpread" module="mpm.core" mode="add" ns="http://www.cemfi.de/mpm/ns/1.0" 
-    xmlns:tei="http://www.tei-c.org/ns/1.0">
+    xmlns:tei="http://www.tei-c.org/ns/1.0"
+    xmlns:schematron="http://purl.oclc.org/dsdl/schematron">
     <tei:gloss>temporal spread</tei:gloss>
     
     <tei:desc>The <tei:gi>temporalSpread</tei:gi> transformer offsets all elements at a given time by a certain amount defined by a power function.</tei:desc>

--- a/src/specs/temporalSpread.xml
+++ b/src/specs/temporalSpread.xml
@@ -35,7 +35,6 @@
                     </schematron:rule>
                 </tei:constraint>
             </tei:constraintSpec>
-            </tei:datatype>
             <tei:defaultVal>100%</tei:defaultVal>
         </tei:attDef>
         <tei:attDef ident="noteoff.shift" usage="opt" mode="change">


### PR DESCRIPTION
For the docs generation, minor fixes has been added.

- schematron ns [temporalSpread.xml]
- ending tag [note.xml]
- exemplum ID's [note.xml]
- xinclude note [mpm.odd]