### PR TITLE
v3.0.1 hardening note's definition

### DIFF
--- a/src/mpm.odd
+++ b/src/mpm.odd
@@ -14,7 +14,7 @@
             </tei:titleStmt>
             
             <tei:editionStmt>
-                <tei:edition n="3.0.0"/>
+                <tei:edition n="3.0.1"/>
             </tei:editionStmt>
             
             <tei:publicationStmt>
@@ -80,6 +80,13 @@
                     <tei:item>Added <tei:att>repetitions</tei:att> to <tei:gi>ornament</tei:gi> to set the amount of repetitions of the optional <tei:att>note.order</tei:att>'s repetition group.</tei:item>
                     <tei:item>Extended the <tei:att>note.order</tei:att> to support the usage of <tei:gi>note</tei:gi> from an <tei:gi>ornament</tei:gi>'s note pool, repetitions and chord-groups.</tei:item>
                     <tei:item>Added <tei:att>alignment</tei:att> to <tei:gi>temporalSpread</tei:gi> to position the frame of an <tei:gi>ornament</tei:gi> to the end of the principal note.</tei:item>
+                </tei:list>
+            </tei:change>
+            <tei:change status="3.0.1" who="Lars Engeln">
+                <tei:list>
+                    <tei:item>Sets <tei:att>midi.pitch</tei:att> of <tei:gi>note</tei:gi> to optional.</tei:item> 
+                    <tei:item>Adds schematron that only one pitch-specifying attribute of a <tei:gi>note</tei:gi> can be set.</tei:item>
+                    <tei:item>Adds schematron and remark that the <tei:att>note.order</tei:att> of an <tei:gi>ornament</tei:gi> need an ID of a MSM note (a note not being specified in the note pool) to function as principal note.</tei:item>
                 </tei:list>
             </tei:change>
         </tei:revisionDesc>

--- a/src/specs/note.xml
+++ b/src/specs/note.xml
@@ -16,8 +16,15 @@
         <tei:empty/>
     </tei:content>
 
+    <tei:constraintSpec ident="note-pitch-mutual-exclusion" scheme="schematron">
+        <tei:desc>Only one of the three pitch-specifying attributes <tei:att>midi.pitch</tei:att>, <tei:att>interval.chromatic</tei:att>, or <tei:att>interval.diatonic</tei:att> may be set on a single <tei:gi>note</tei:gi> element.</tei:desc>
+        <tei:constraint>
+            <schematron:assert test="count(@midi.pitch | @interval.chromatic | @interval.diatonic) le 1">Only one of the attributes 'midi.pitch', 'interval.chromatic', or 'interval.diatonic' may be set on a note element.</schematron:assert>
+        </tei:constraint>
+    </tei:constraintSpec>
+
     <tei:attList>
-        <tei:attDef ident="midi.pitch" usage="req">
+        <tei:attDef ident="midi.pitch" usage="opt">
             <tei:gloss>note pitch according to MIDI</tei:gloss>
             <tei:datatype>
                 <tei:dataRef name="integer">
@@ -59,4 +66,6 @@
             </ornament>
         </egXML>
     </tei:exemplum>
+
+    <tei:remarks><tei:p>Only one of the three pitch-specifying attributes can be set on a single note element. Whereby <tei:att>midi.pitch</tei:att> is the most explicit, <tei:att>interval.chromatic</tei:att> is the more general interval specification, and <tei:att>interval.diatonic</tei:att> is context-sensitive.</tei:p></tei:remarks>
 </tei:elementSpec>

--- a/src/specs/ornament.xml
+++ b/src/specs/ornament.xml
@@ -2,7 +2,8 @@
 <?xml-model href="https://tei-c.org/release/xml/tei/custom/schema/relaxng/tei_odds.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://tei-c.org/release/xml/tei/custom/schema/relaxng/tei_odds.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <tei:elementSpec ident="ornament" module="mpm.core" mode="add" ns="http://www.cemfi.de/mpm/ns/1.0" 
-    xmlns:tei="http://www.tei-c.org/ns/1.0">
+    xmlns:tei="http://www.tei-c.org/ns/1.0"
+    xmlns:schematron="http://purl.oclc.org/dsdl/schematron">
     <tei:gloss>ornament</tei:gloss>
     
     <tei:desc>An <tei:gi>ornament</tei:gi> describes how ornaments like arpeggios, trills, mordents, turns, tremolos, etc. are to be performed.</tei:desc>
@@ -18,6 +19,18 @@
     <tei:content>
         <tei:elementRef key="note" minOccurs="0" maxOccurs="unbounded"/>
     </tei:content>
+
+    <tei:constraintSpec ident="ornament-principal-note-ref" scheme="schematron">
+        <tei:desc>If <tei:att>note.order</tei:att> contains ID references, at least one must not refer to a child <tei:gi>note</tei:gi> element, so that a principal note (an MSM note) can be identified.</tei:desc>
+        <tei:constraint>
+            <schematron:rule context="attribute::note.order[contains(., '#')]">
+                <schematron:assert role="warning" test="
+                    some $id in tokenize(., '\s+')[starts-with(., '#')]
+                    satisfies not(substring($id, 2) = parent::*/*[local-name()='note']/@xml:id)
+                ">@note.order should contain at least one ID reference that is not an ID of a child note element (that can be treated as the principal note).</schematron:assert>
+            </schematron:rule>
+        </tei:constraint>
+    </tei:constraintSpec>
 
     <tei:attList>
         <tei:attDef ident="scale" mode="change" usage="opt">
@@ -63,5 +76,6 @@
         <tei:p>The use of attribute <tei:att>name.ref</tei:att> requires the presence of an <tei:gi>ornamentDef</tei:gi> of the same name within an ornament style. In the <tei:gi>ornamentationMap</tei:gi> there must be a <tei:gi>style</tei:gi> element switching to this style before the first reference to an <tei:gi>ornamentationDef</tei:gi> within that style.</tei:p>
         <tei:p>If the <tei:gi>ornament</tei:gi> has a pool of <tei:gi>note</tei:gi>s as children, these notes can be referenced in the <tei:att>note.order</tei:att> attribute for usage, but could also stay unused.
         Within the pool of notes, the notes' order have no semantic meaning, as the order is determined by the <tei:att>note.order</tei:att> attribute.</tei:p>
+        <tei:p>The <tei:att>note.order</tei:att> does need to contain an ID reference to a MSM note that is treated as the corresponding principal note. If no such note is found, all <tei:gi>note</tei:gi>'s need an explicit <tei:att>midi.pitch</tei:att>, or the ornament cannot be rendered correctly.</tei:p>
     </tei:remarks>
 </tei:elementSpec>


### PR DESCRIPTION
v3.0.1
- sets midi.pitch of note to optional
- adds schematron that only one pitch-specifying attribut can be set
- adds that note.order of a ornament need an ID of a MSM note (a note not being specified in the note pool) to function as principal note
