### PR TITLE
v3.0.2

### DIFF
--- a/src/mpm.odd
+++ b/src/mpm.odd
@@ -725,13 +725,13 @@
                     <dated>
                         <ornamentationMap>
                             <style date="0.0" name.ref="your style"/>
-                            <ornament date="4860.0" name.ref="arpeggio" scale="10.0" note.order="#n96 #n97 #n98"/> 
+                            <ornament correspondence="#n96" date="4860.0" name.ref="arpeggio" scale="10.0" note.order="#n96 #n97 #n98"/> 
                         </ornamentationMap>
                     </dated>
                 </egXML>
                 
                 <tei:p>The <tei:gi>ornament</tei:gi> element's attribute <tei:att>scale</tei:att> (optional, default value is <tei:val>0.0</tei:val>) has the same function as in <tei:gi>accentuationPattern</tei:gi>. It scales the ornament's dynamics gradient to loudness/velocity values.
-                The <tei:gi>ornament</tei:gi> element may contain <tei:gi>note</tei:gi> elements, which define a pool of notes as alterations (e.g. grace notes, passing notes or trill notes) of the principal note via <tei:att>interval.chromatic</tei:att> in (chromatic) halftone steps (see the example of an trill and upper turn below) or via <tei:att>interval.diatonic</tei:att> in (diatonic) tone steps.
+                The <tei:gi>ornament</tei:gi> should always have a <tei:att>correspondence</tei:att> attribute (ID reference to an element) to point to the principal note. In addition, the <tei:gi>ornament</tei:gi> element may contain <tei:gi>note</tei:gi> elements, which define a pool of notes as alterations (e.g. grace notes, passing notes or trill notes) of the principal note via <tei:att>interval.chromatic</tei:att> in (chromatic) halftone steps (see the example of an trill and upper turn below) or via <tei:att>interval.diatonic</tei:att> in (diatonic) tone steps.
                 With <tei:att>note.order</tei:att> (optional) we can specify which notes in the current scope and note pool are part of the ornament and in which sequence. Possible values are "ascending pitch" (orders all notes at <tei:att>date</tei:att> by increasing pitch), "descending pitch" (opposite of "ascending pitch"), or a space separated list of note ID references as in the above code example. In the space separated list of note ID references, chords (notes to be played at the same time) are defined within "["/"]" (e.g. "[ #n97 #98 ]"), and a repetition group, that is repeated <tei:att>repetitions</tei:att> times, is defined with "|:"/":|" (e.g. "|: #n95 #96 :|"). These annotation symbols are space sparated as well.
                 
                 </tei:p>
@@ -754,10 +754,10 @@
                     <dated>
                         <ornamentationMap>
                             <style date="0.0" name.ref="my style"/>
-                            <ornament date="4860.0" name.ref="trill" note.order="|: #on1 #n96 :|" repetitions="3">
+                            <ornament correspondence="#n96" date="4860.0" name.ref="trill" note.order="|: #on1 #n96 :|" repetitions="3">
                                 <note xml:id="on1" interval.chromatic="2.0"/>
                             </ornament> 
-                            <ornament date="6300.0" name.ref="upper turn" note.order="#on2 #n97 #on3 #n97">
+                            <ornament correspondence="#n97" date="6300.0" name.ref="upper turn" note.order="#on2 #n97 #on3 #n97">
                                 <note xml:id="on2" interval.chromatic="2"/>
                                 <note xml:id="on3" interval.chromatic="-1"/>
                             </ornament>

--- a/src/mpm.odd
+++ b/src/mpm.odd
@@ -91,7 +91,7 @@
             </tei:change>
             <tei:change status="3.0.2" who="Lars Engeln">
                 <tei:list>
-                    <tei:item>Adds <tei:att>correspondence</tei:att> to <tei:gi>ornament</tei:gi> to explicitly link it to a MSM element.</tei:item>
+                    <tei:item>Adds <tei:att>noteid</tei:att> to <tei:gi>ornament</tei:gi> to explicitly link it to a MSM element.</tei:item>
                 </tei:list>
 
             </tei:change>
@@ -725,13 +725,13 @@
                     <dated>
                         <ornamentationMap>
                             <style date="0.0" name.ref="your style"/>
-                            <ornament correspondence="#n96" date="4860.0" name.ref="arpeggio" scale="10.0" note.order="#n96 #n97 #n98"/> 
+                            <ornament noteid="#n96" date="4860.0" name.ref="arpeggio" scale="10.0" note.order="#n96 #n97 #n98"/> 
                         </ornamentationMap>
                     </dated>
                 </egXML>
                 
                 <tei:p>The <tei:gi>ornament</tei:gi> element's attribute <tei:att>scale</tei:att> (optional, default value is <tei:val>0.0</tei:val>) has the same function as in <tei:gi>accentuationPattern</tei:gi>. It scales the ornament's dynamics gradient to loudness/velocity values.
-                The <tei:gi>ornament</tei:gi> should always have a <tei:att>correspondence</tei:att> attribute (ID reference to an element) to point to the principal note. In addition, the <tei:gi>ornament</tei:gi> element may contain <tei:gi>note</tei:gi> elements, which define a pool of notes as alterations (e.g. grace notes, passing notes or trill notes) of the principal note via <tei:att>interval.chromatic</tei:att> in (chromatic) halftone steps (see the example of an trill and upper turn below) or via <tei:att>interval.diatonic</tei:att> in (diatonic) tone steps.
+                The <tei:gi>ornament</tei:gi> should always have a <tei:att>noteid</tei:att> attribute (ID reference to an element) to point to the principal note. In addition, the <tei:gi>ornament</tei:gi> element may contain <tei:gi>note</tei:gi> elements, which define a pool of notes as alterations (e.g. grace notes, passing notes or trill notes) of the principal note via <tei:att>interval.chromatic</tei:att> in (chromatic) halftone steps (see the example of an trill and upper turn below) or via <tei:att>interval.diatonic</tei:att> in (diatonic) tone steps.
                 With <tei:att>note.order</tei:att> (optional) we can specify which notes in the current scope and note pool are part of the ornament and in which sequence. Possible values are "ascending pitch" (orders all notes at <tei:att>date</tei:att> by increasing pitch), "descending pitch" (opposite of "ascending pitch"), or a space separated list of note ID references as in the above code example. In the space separated list of note ID references, chords (notes to be played at the same time) are defined within "["/"]" (e.g. "[ #n97 #98 ]"), and a repetition group, that is repeated <tei:att>repetitions</tei:att> times, is defined with "|:"/":|" (e.g. "|: #n95 #96 :|"). These annotation symbols are space sparated as well.
                 
                 </tei:p>
@@ -754,10 +754,10 @@
                     <dated>
                         <ornamentationMap>
                             <style date="0.0" name.ref="my style"/>
-                            <ornament correspondence="#n96" date="4860.0" name.ref="trill" note.order="|: #on1 #n96 :|" repetitions="3">
+                            <ornament noteid="#n96" date="4860.0" name.ref="trill" note.order="|: #on1 #n96 :|" repetitions="3">
                                 <note xml:id="on1" interval.chromatic="2.0"/>
                             </ornament> 
-                            <ornament correspondence="#n97" date="6300.0" name.ref="upper turn" note.order="#on2 #n97 #on3 #n97">
+                            <ornament noteid="#n97" date="6300.0" name.ref="upper turn" note.order="#on2 #n97 #on3 #n97">
                                 <note xml:id="on2" interval.chromatic="2"/>
                                 <note xml:id="on3" interval.chromatic="-1"/>
                             </ornament>

--- a/src/mpm.odd
+++ b/src/mpm.odd
@@ -89,6 +89,12 @@
                     <tei:item>Adds schematron and remark that the <tei:att>note.order</tei:att> of an <tei:gi>ornament</tei:gi> need an ID of a MSM note (a note not being specified in the note pool) to function as principal note.</tei:item>
                 </tei:list>
             </tei:change>
+            <tei:change status="3.0.2" who="Lars Engeln">
+                <tei:list>
+                    <tei:item>Adds <tei:att>correspondence</tei:att> to <tei:gi>ornament</tei:gi> to explicitly link it to a MSM element.</tei:item>
+                </tei:list>
+
+            </tei:change>
         </tei:revisionDesc>
     </tei:teiHeader>
     

--- a/src/specs/note.xml
+++ b/src/specs/note.xml
@@ -57,11 +57,11 @@
             The second <tei:gi>ornament</tei:gi> defines a half tone trill ornament, starting with the auxiliary note (#n4) and landing on the principal note (#princNote2), with no repetition as the <tei:att>repetitions</tei:att> attribute is not specified and <tei:val>0</tei:val> by default.
         </tei:p>
         <egXML xmlns="http://www.tei-c.org/ns/Examples">
-            <ornament date="0.0" name.ref="upper turn" note.order="#n2 #princNote1 #n3 #princNote1">
+            <ornament correspondence="#princNote1" date="0.0" name.ref="upper turn" note.order="#n2 #princNote1 #n3 #princNote1">
                 <note xml:id="n2" interval.chromatic="1.0"/>
                 <note xml:id="n3" interval.chromatic="-1.0"/>
             </ornament>
-            <ornament date="720.0" name.ref="trill" note.order="|: #n4 #princNote2 :|">
+            <ornament correspondence="#princNote2" date="720.0" name.ref="trill" note.order="|: #n4 #princNote2 :|">
                 <note xml:id="n4" interval.chromatic="1.0"/>
             </ornament>
         </egXML>

--- a/src/specs/note.xml
+++ b/src/specs/note.xml
@@ -57,11 +57,11 @@
             The second <tei:gi>ornament</tei:gi> defines a half tone trill ornament, starting with the auxiliary note (#n4) and landing on the principal note (#princNote2), with no repetition as the <tei:att>repetitions</tei:att> attribute is not specified and <tei:val>0</tei:val> by default.
         </tei:p>
         <egXML xmlns="http://www.tei-c.org/ns/Examples">
-            <ornament correspondence="#princNote1" date="0.0" name.ref="upper turn" note.order="#n2 #princNote1 #n3 #princNote1">
+            <ornament noteid="#princNote1" date="0.0" name.ref="upper turn" note.order="#n2 #princNote1 #n3 #princNote1">
                 <note xml:id="n2" interval.chromatic="1.0"/>
                 <note xml:id="n3" interval.chromatic="-1.0"/>
             </ornament>
-            <ornament correspondence="#princNote2" date="720.0" name.ref="trill" note.order="|: #n4 #princNote2 :|">
+            <ornament noteid="#princNote2" date="720.0" name.ref="trill" note.order="|: #n4 #princNote2 :|">
                 <note xml:id="n4" interval.chromatic="1.0"/>
             </ornament>
         </egXML>

--- a/src/specs/ornament.xml
+++ b/src/specs/ornament.xml
@@ -21,13 +21,14 @@
     </tei:content>
 
     <tei:constraintSpec ident="ornament-principal-note-ref" scheme="schematron">
-        <tei:desc>If <tei:att>note.order</tei:att> contains ID references, at least one must not refer to a child <tei:gi>note</tei:gi> element, so that a principal note (an MSM note) can be identified.</tei:desc>
+        <tei:desc>If no <tei:att>correspondence</tei:att> is givin, <tei:att>note.order</tei:att> should contain ID references, at least one must not refer to a child <tei:gi>note</tei:gi> element, so that a principal note (an MSM note) can be identified.</tei:desc>
         <tei:constraint>
             <schematron:rule context="attribute::note.order[contains(., '#')]">
                 <schematron:assert role="warning" test="
-                    some $id in tokenize(., '\s+')[starts-with(., '#')]
-                    satisfies not(substring($id, 2) = parent::*/*[local-name()='note']/@xml:id)
-                ">@note.order should contain at least one ID reference that is not an ID of a child note element (that can be treated as the principal note).</schematron:assert>
+                    (some $id in tokenize(., '\s+')[starts-with(., '#')]
+                    satisfies not(substring($id, 2) = parent::*/*[local-name()='note']/@xml:id))
+                    or (parent::*/@correspondence and parent::*/@correspondence[starts-with(., '#')])
+                ">provide a @correpondence, or @note.order should contain at least one ID reference that is not an ID of a child note element (that can be treated as the principal note).</schematron:assert>
             </schematron:rule>
         </tei:constraint>
     </tei:constraintSpec>
@@ -53,6 +54,13 @@
             <tei:defaultVal>0</tei:defaultVal>
         </tei:attDef>
         
+        <tei:attDef ident="correspondence" usage="opt">
+            <tei:gloss>correspondence</tei:gloss>
+            <tei:desc>This attribute explicitly links the ornament to a MSM element. This is needed especially if the <tei:att>note.order</tei:att> does not contain a reference to a MSM note not being in the note pool. Best is to always provide a <tei:att>correspondence</tei:att>.</tei:desc>
+            <tei:datatype>
+                <tei:dataRef name="string"/>
+            </tei:datatype>
+        </tei:attDef>
     </tei:attList>
     
     <tei:exemplum>
@@ -64,9 +72,9 @@
             The third <tei:gi>ornament</tei:gi> applies a half tone (#n1) trill to the note (#princNote), repeating the trill pattern three times within the time frame of the ornament. So, it is played four times.
         </tei:p>
         <egXML xmlns="http://www.tei-c.org/ns/Examples">
-            <ornament date="0.0" name.ref="arpeggio" scale="20.0" note.order="ascending pitch"/>
+            <ornament correspondence="#msmNote1" date="0.0" name.ref="arpeggio" scale="20.0" note.order="ascending pitch"/>
             <ornament date="720.0" name.ref="arpeggio" scale="20.0" note.order="#id1 #id3 #id2 #id4"/>
-            <ornament date="720.0" name.ref="trill" note.order="|: #n1 #princNote :|" repetitions="3">
+            <ornament correspondence="#princNote" date="720.0" name.ref="trill" note.order="|: #n1 #princNote :|" repetitions="3">
                 <note xml:id="n1" interval.chromatic="1.0"/>
             </ornament>
         </egXML>

--- a/src/specs/ornament.xml
+++ b/src/specs/ornament.xml
@@ -12,6 +12,7 @@
         <tei:memberOf key="att.id"/>
         <tei:memberOf key="att.note.order"/>
         <tei:memberOf key="att.reference.name"/>
+        <tei:memberOf key="att.reference.noteid"/>
         <tei:memberOf key="att.scale"/>
         <tei:memberOf key="att.time.symbolic.date"/>
     </tei:classes>
@@ -21,14 +22,14 @@
     </tei:content>
 
     <tei:constraintSpec ident="ornament-principal-note-ref" scheme="schematron">
-        <tei:desc>If no <tei:att>correspondence</tei:att> is givin, <tei:att>note.order</tei:att> should contain ID references, at least one must not refer to a child <tei:gi>note</tei:gi> element, so that a principal note (an MSM note) can be identified.</tei:desc>
+        <tei:desc>If no <tei:att>noteid</tei:att> is givin, <tei:att>note.order</tei:att> should contain ID references, at least one must not refer to a child <tei:gi>note</tei:gi> element, so that a principal note (an MSM note) can be identified.</tei:desc>
         <tei:constraint>
             <schematron:rule context="attribute::note.order[contains(., '#')]">
                 <schematron:assert role="warning" test="
                     (some $id in tokenize(., '\s+')[starts-with(., '#')]
                     satisfies not(substring($id, 2) = parent::*/*[local-name()='note']/@xml:id))
-                    or (parent::*/@correspondence and parent::*/@correspondence[starts-with(., '#')])
-                ">provide a @correpondence, or @note.order should contain at least one ID reference that is not an ID of a child note element (that can be treated as the principal note).</schematron:assert>
+                    or (parent::*/@noteid and parent::*/@noteid[starts-with(., '#')])
+                ">provide a @noteid, or @note.order should contain at least one ID reference that is not an ID of a child note element (that can be treated as the principal note).</schematron:assert>
             </schematron:rule>
         </tei:constraint>
     </tei:constraintSpec>
@@ -53,28 +54,19 @@
             </tei:datatype>
             <tei:defaultVal>0</tei:defaultVal>
         </tei:attDef>
-        
-        <tei:attDef ident="correspondence" usage="opt">
-            <tei:gloss>correspondence</tei:gloss>
-            <tei:desc>This attribute explicitly links the ornament to a MSM element. This is needed especially if the <tei:att>note.order</tei:att> does not contain a reference to a MSM note not being in the note pool. Best is to always provide a <tei:att>correspondence</tei:att>.</tei:desc>
-            <tei:datatype>
-                <tei:dataRef name="string"/>
-            </tei:datatype>
-        </tei:attDef>
     </tei:attList>
     
     <tei:exemplum>
         <tei:p>
             The first <tei:gi>ornament</tei:gi> applies an upwards arpeggiation to all notes (listed lowest to highest pitch) at date 0.0 with 
             a scaled dynamic gradient.
-            The second <tei:gi>ornament</tei:gi> defines an arpeggiation of the notes listed in
-            <tei:att>note.order</tei:att> in the given order.
+            The second <tei:gi>ornament</tei:gi> defines an arpeggiation of the notes listed in <tei:att>note.order</tei:att> in the given order.
             The third <tei:gi>ornament</tei:gi> applies a half tone (#n1) trill to the note (#princNote), repeating the trill pattern three times within the time frame of the ornament. So, it is played four times.
         </tei:p>
         <egXML xmlns="http://www.tei-c.org/ns/Examples">
-            <ornament correspondence="#msmNote1" date="0.0" name.ref="arpeggio" scale="20.0" note.order="ascending pitch"/>
+            <ornament noteid="#msmNote1" date="0.0" name.ref="arpeggio" scale="20.0" note.order="ascending pitch"/>
             <ornament date="720.0" name.ref="arpeggio" scale="20.0" note.order="#id1 #id3 #id2 #id4"/>
-            <ornament correspondence="#princNote" date="720.0" name.ref="trill" note.order="|: #n1 #princNote :|" repetitions="3">
+            <ornament noteid="#princNote" date="720.0" name.ref="trill" note.order="|: #n1 #princNote :|" repetitions="3">
                 <note xml:id="n1" interval.chromatic="1.0"/>
             </ornament>
         </egXML>
@@ -83,7 +75,7 @@
     <tei:remarks>
         <tei:p>The use of attribute <tei:att>name.ref</tei:att> requires the presence of an <tei:gi>ornamentDef</tei:gi> of the same name within an ornament style. In the <tei:gi>ornamentationMap</tei:gi> there must be a <tei:gi>style</tei:gi> element switching to this style before the first reference to an <tei:gi>ornamentationDef</tei:gi> within that style.</tei:p>
         <tei:p>If the <tei:gi>ornament</tei:gi> has a pool of <tei:gi>note</tei:gi>s as children, these notes can be referenced in the <tei:att>note.order</tei:att> attribute for usage, but could also stay unused.
-        Within the pool of notes, the notes' order have no semantic meaning, as the order is determined by the <tei:att>note.order</tei:att> attribute.</tei:p>
-        <tei:p>The <tei:att>note.order</tei:att> does need to contain an ID reference to a MSM note that is treated as the corresponding principal note. If no such note is found, all <tei:gi>note</tei:gi>'s need an explicit <tei:att>midi.pitch</tei:att>, or the ornament cannot be rendered correctly.</tei:p>
+        Within the pool of notes, the order of these note elements have no semantic meaning, as the order is determined by the <tei:att>note.order</tei:att> attribute.</tei:p>
+        <tei:p>The <tei:gi>ornament</tei:gi> does need a <tei:att>noteid</tei:att> attribute as reference to the principal note (or element) to which the ornament applies. If not providing a <tei:att>noteid</tei:att>, the <tei:att>note.order</tei:att> does need to contain an ID reference to a MSM note that is treated as the corresponding principal note. If no such note is found, all <tei:gi>note</tei:gi>'s need an explicit <tei:att>midi.pitch</tei:att>, or the ornament cannot be rendered correctly.</tei:p>
     </tei:remarks>
 </tei:elementSpec>


### PR DESCRIPTION
adds <tei:att>correspondence</tei:att> to <tei:gi>ornament</tei:gi> to explicitly link it to a MSM element.